### PR TITLE
Fix wrong fixer rule

### DIFF
--- a/publish/.php-cs-fixer.dist.php
+++ b/publish/.php-cs-fixer.dist.php
@@ -21,7 +21,7 @@ $rules = [
     'cast_spaces'                             => true,
     'class_definition'                        => true,
     'compact_nullable_typehint'               => true,
-    'concat_space'                            => ['spacing' => 'one'],
+    'concat_space'                            => ['spacing' => 'none'],
     'declare_equal_normalize'                 => true,
     'elseif'                                  => true,
     'encoding'                                => true,


### PR DESCRIPTION
The included `php-cs-fixer.dist.php` still uses a wrong, mistakenly adopted rule. Laravel doesn't use space when concatenating.

