### PR TITLE
Add purge and safelist option to default tailwind config

### DIFF
--- a/publish/tailwind.config.js
+++ b/publish/tailwind.config.js
@@ -1,5 +1,16 @@
 module.exports = {
     // mode: 'jit',
+    purge: {
+        enabled: true,
+        content: [
+            './resources/js/**/*.vue', 
+            './resources/views/**/*.blade.php'
+        ],
+        safelist: [
+            'bg-blue-500',
+            'text-center'
+        ]
+    },
     variants: {
         extend: {
             backgroundColor: ['active'],


### PR DESCRIPTION
I think `purge` option should be included by default as it's basically used all the time. Also the `safelist` option is very useful, because it makes placeholder elements with some classes, which should not be purged in any case, completely unnecessary.