### PR TITLE
Add allowSyntheticDefaultImports to typescript config

### DIFF
--- a/publish/tsconfig.json
+++ b/publish/tsconfig.json
@@ -5,7 +5,8 @@
     // this enables stricter inference for data properties on `this`
     "strict": true,
     "jsx": "preserve",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
   },
   "include": ["resources/js/**/*"],
   "files": [


### PR DESCRIPTION
This pr adds `allowSyntheticDefaultImports: true` to the typescript config. This allows importing modules like `lodash.debounce`.